### PR TITLE
fix: Resolve webpack build error for web worker

### DIFF
--- a/lib/file-service.ts
+++ b/lib/file-service.ts
@@ -198,11 +198,13 @@ export async function getSheetData(file: File, sheetName: string, onProgress?: P
 
 // Store worker instance globally within the module to reuse
 let fileWorker: Worker | null = null
+import workerUrl from "./file-loader-worker.ts?url" // Import the worker URL
 
 function getWorker(): Worker {
   if (!fileWorker) {
-    fileWorker = new Worker(new URL("./file-loader-worker.ts", import.meta.url), {
-      type: "module",
+    // Use the imported URL to instantiate the worker
+    fileWorker = new Worker(workerUrl, {
+      type: "module", // ESM worker
     })
   }
   return fileWorker

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,26 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  webpack: (config, { isServer }) => {
+    // Rule for ?url imports to ensure they are treated as asset/resource
+    // for web workers (and other assets if needed)
+    config.module.rules.push({
+      // Matches `.ts` or `.js` files ending with `?url`
+      test: /\.(ts|js)$/,
+      resourceQuery: /url/, // Only process if `?url` is appended
+      type: "asset/resource",
+      generator: {
+        // Output worker files to static/workers directory to keep them organized
+        // and prevent conflicts with other static chunks.
+        filename: isServer
+          ? "../static/workers/[name].[hash][ext]" // For server, path relative to .next/server
+          : "static/workers/[name].[hash][ext]",   // For client, path relative to .next/static
+      },
+    });
+
+    // Important: return the modified config
+    return config;
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
Adjusted web worker instantiation and Next.js webpack configuration to correctly bundle and reference the TypeScript web worker.

- In `lib/file-service.ts`, changed worker instantiation to use `import workerUrl from "./file-loader-worker.ts?url";` and then `new Worker(workerUrl)`.
- Added a webpack rule to `next.config.mjs` to handle `?url` imports for `.ts` (and `.js`) files, treating them as `asset/resource` and outputting them to a `static/workers/` directory.

This resolves build failures related to worker bundling in Next.js.