### PR TITLE
Fix: Prevent UI freeze when loading large Excel files

### DIFF
--- a/components/file-upload-form.tsx
+++ b/components/file-upload-form.tsx
@@ -11,7 +11,12 @@ import { ReconciliationResults } from "./reconciliation-results"
 import { SheetSelector } from "./sheet-selector"
 import { ColumnMapper, type ColumnMapping } from "./column-mapper"
 import { processFiles } from "@/lib/reconciliation"
-import { getWorkbookSheets, getSheetColumns, terminateFileWorker } from "@/lib/file-service"
+// Use worker-based functions for sheets and columns
+import {
+  getWorkbookSheetsWithWorker,
+  getSheetColumnsWithWorker,
+  terminateFileWorker,
+} from "@/lib/file-service"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Loader2 } from "lucide-react"
 import { Steps } from "./steps"
@@ -77,8 +82,9 @@ export function FileUploadForm() {
       setProgress({ stage: `Loading sheets from ${fileNum === 1 ? "File 1" : "File 2"}...`, percent: 0 })
 
       try {
-        const sheetNames = await getWorkbookSheets(file, (stage, percent) => {
-          setProgress({ stage, percent })
+        // Use getWorkbookSheetsWithWorker
+        const sheetNames = await getWorkbookSheetsWithWorker(file, (stage, percent) => {
+          setProgress({ stage: `File ${fileNum}: ${stage}`, percent })
         })
 
         if (fileNum === 1) {
@@ -133,7 +139,8 @@ export function FileUploadForm() {
 
         try {
           setProgress({ stage: "Loading columns from File 1...", percent: 0 })
-          columns1 = await getSheetColumns(file1, selectedSheet1, (stage, percent) => {
+          // Use getSheetColumnsWithWorker
+          columns1 = await getSheetColumnsWithWorker(file1, selectedSheet1, (stage, percent) => {
             setProgress({ stage: `File 1: ${stage}`, percent })
           })
         } catch (error: any) {
@@ -142,7 +149,8 @@ export function FileUploadForm() {
 
         try {
           setProgress({ stage: "Loading columns from File 2...", percent: 0 })
-          columns2 = await getSheetColumns(file2, selectedSheet2, (stage, percent) => {
+          // Use getSheetColumnsWithWorker
+          columns2 = await getSheetColumnsWithWorker(file2, selectedSheet2, (stage, percent) => {
             setProgress({ stage: `File 2: ${stage}`, percent })
           })
         } catch (error: any) {


### PR DESCRIPTION
Refactored the file upload form to use web workers for loading Excel sheet names and column headers. Previously, these operations were performed on the main thread, causing the UI to become unresponsive with large files.

Changes:
- Modified `components/file-upload-form.tsx` to call `getWorkbookSheetsWithWorker` instead of `getWorkbookSheets`.
- Modified `components/file-upload-form.tsx` to call `getSheetColumnsWithWorker` instead of `getSheetColumns`.

This ensures that all intensive Excel parsing operations (sheet discovery, column extraction, and data processing) are now handled off the main thread, improving UI responsiveness and user experience with large datasets.